### PR TITLE
regis3.RegValueEntry.WriteRegFileFormat(...) fix for Kind == RegValue…

### DIFF
--- a/regdiff/regis3/RegValueEntry.cs
+++ b/regdiff/regis3/RegValueEntry.cs
@@ -534,9 +534,13 @@ namespace regis3
                 {
                     output.WriteLine("{0}=dword:{1}", name, ((int)Value).ToString("x8"));
                 }
-                else
+                else if (Value is long)
                 {
                     output.WriteLine("{0}=dword:{1}", name, ((long)Value).ToString("x8"));
+                }
+                else if ((Value != null) && (Value is byte[]))
+                {
+                    WriteHexEncodedValue(output, name, Value as byte[]);
                 }
             }
             else if( (Value != null) && (Value is byte[]) )


### PR DESCRIPTION
…EntryKind.DWord case.

Without this fix, an invalid cast exception will occur when writing the output file. For example, for a case like:
[HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Enum\PCI\VEN_8086&DEV_100E&SUBSYS_001E8086&REV_02\3&267a616a&0&18\Device Parameters\Interrupt Management\Routing Info]
"Flags"=hex(4):02